### PR TITLE
Initialze with Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# caption-tracker
-A TVKitchen instance designed to track captions
+# C4CM Caption Tracker
+
+This project uses the [TV Kitchen](https://tv.kitchen) to extract closed captions from an array of HD HomeRun devices.
+
+Captions are written to SRT files and uploaded to Amazon S3.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A service that tracks captions using the TV Kitchen",
   "main": "index.js",
   "scripts": {
+    "start:kafka": "docker-compose -f services/kafka/docker-compose.yml up -d",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "caption-tracker",
+  "version": "0.0.1",
+  "description": "A service that tracks captions using the TV Kitchen",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Center-for-Cooperative-Media/caption-tracker.git"
+  },
+  "author": "Bad Idea Factory <biffuddotcom@biffud.com>",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/Center-for-Cooperative-Media/caption-tracker/issues"
+  },
+  "homepage": "https://github.com/Center-for-Cooperative-Media/caption-tracker#readme"
+}

--- a/services/kafka/docker-compose.yml
+++ b/services/kafka/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+    restart: always
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    expose:
+      - "9093"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: always


### PR DESCRIPTION
This adds the dockerfile for Kafka (taken from the TV Kitchen cookboook) which will make it easy to spin up Kafka on the deployment machine.